### PR TITLE
(Rebased) AssetRipper.CLI

### DIFF
--- a/AssetRipper.sln
+++ b/AssetRipper.sln
@@ -155,6 +155,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssetRipper.GUI.Web", "Sour
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssetRipper.Export.Modules.Models", "Source\AssetRipper.Export.Modules.Models\AssetRipper.Export.Modules.Models.csproj", "{B827502A-EA76-4C16-B246-0E625A7ED80E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssetRipper.CLI", "Source\AssetRipper.CLI\AssetRipper.CLI.csproj", "{AD0EA8FF-C0CA-447F-97E9-D02EED4A4FC5}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssetRipper.GUI.Web.Tests", "Source\AssetRipper.GUI.Web.Tests\AssetRipper.GUI.Web.Tests.csproj", "{9EDD3621-6E2B-41AD-8F6A-F8C4CD113566}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssetRipper.GUI.Localizations.SourceGenerator", "Source\AssetRipper.GUI.Localizations.SourceGenerator\AssetRipper.GUI.Localizations.SourceGenerator.csproj", "{ADE822A6-9D1E-98B1-696F-25D37BFCF7CA}"
@@ -327,6 +329,10 @@ Global
 		{B827502A-EA76-4C16-B246-0E625A7ED80E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B827502A-EA76-4C16-B246-0E625A7ED80E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B827502A-EA76-4C16-B246-0E625A7ED80E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD0EA8FF-C0CA-447F-97E9-D02EED4A4FC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD0EA8FF-C0CA-447F-97E9-D02EED4A4FC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD0EA8FF-C0CA-447F-97E9-D02EED4A4FC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD0EA8FF-C0CA-447F-97E9-D02EED4A4FC5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9EDD3621-6E2B-41AD-8F6A-F8C4CD113566}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9EDD3621-6E2B-41AD-8F6A-F8C4CD113566}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9EDD3621-6E2B-41AD-8F6A-F8C4CD113566}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/Source/AssetRipper.CLI/AssetRipper.CLI.csproj
+++ b/Source/AssetRipper.CLI/AssetRipper.CLI.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<ServerGarbageCollection>true</ServerGarbageCollection>
+		<InvariantGlobalization>true</InvariantGlobalization>
+		<EnableUnsafeUTF7Encoding>false</EnableUnsafeUTF7Encoding>
+		<OptimizationPreference>Size</OptimizationPreference>
+		<OutputType>Exe</OutputType>
+		<PublishAot>true</PublishAot>
+		<TrimmerSingleWarn>false</TrimmerSingleWarn>
+		<OutputPath>..\0Bins\AssetRipper.CLI\$(Configuration)\</OutputPath>
+		<IntermediateOutputPath>..\0Bins\obj\AssetRipper.CLI\$(Configuration)\</IntermediateOutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
+		<DebuggerSupport>false</DebuggerSupport>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\AssetRipper.GUI.Web\AssetRipper.GUI.Web.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/Source/AssetRipper.CLI/Program.cs
+++ b/Source/AssetRipper.CLI/Program.cs
@@ -1,0 +1,103 @@
+using System.ComponentModel;
+
+using Ookii.CommandLine;
+using Ookii.CommandLine.Validation;
+
+using AssetRipper.GUI.Web;
+using AssetRipper.Import.Logging;
+using AssetRipper.Import.Utils;
+using AssetRipper.IO.Files.Utils;
+
+static int Quit(string message)
+{
+	Logger.Error(message);
+	Environment.Exit(1);
+	return 1;
+}
+
+Console.WriteLine(WelcomeMessage.AsciiArt);
+var argsParsed = Arguments.Parse(args);
+if (argsParsed is null)
+{
+	return Quit("failed to parse command-line arguments");
+}
+if (argsParsed.Log)
+{
+	var logPath = argsParsed.LogPath;
+	if (string.IsNullOrEmpty(logPath))
+	{
+		logPath = ExecutingDirectory.Combine($"AssetRipper_{DateTime.Now:yyyyMMdd_HHmmss}.log");
+		WebApplicationLauncher.RotateLogs(logPath);
+	}
+	Logger.Add(new FileLogger(logPath));
+}
+Logger.LogSystemInformation("AssetRipper");
+Logger.Add(new ConsoleLogger());
+
+DirectoryInfo diSource = new(argsParsed.SourceDir);
+if (!diSource.Exists)
+{
+	return Quit($"no such source dir \"{argsParsed.SourceDir}\"");
+}
+
+DirectoryInfo diOutput = new(argsParsed.OutputDir);
+if (diOutput.Exists)
+{
+	if (diOutput.EnumerateFileSystemInfos().Any())
+	{
+		return Quit($"output dir \"{argsParsed.OutputDir}\" not empty");
+	}
+	// else fall through
+}
+else
+{
+	if (File.Exists(argsParsed.OutputDir))
+	{
+		return Quit($"output \"{argsParsed.OutputDir}\" exists but is not an empty directory");
+	}
+	diOutput.Create();
+}
+
+GameFileLoader.LoadAndProcess([ diSource.FullName ]);
+if (argsParsed.Mode is ExtractMode.UnityProject)
+{
+	GameFileLoader.ExportUnityProject(diOutput.FullName);
+}
+else
+{
+	GameFileLoader.ExportPrimaryContent(diOutput.FullName);
+}
+
+return 0;
+
+[GeneratedParser]
+[ParseOptions(IsPosix = true)]
+internal sealed partial class Arguments
+{
+	[CommandLineArgument(IsPositional = true)]
+	[Description("Selects what to extract.")]
+	[ValidateEnumValue]
+	public required ExtractMode Mode { get; set; }
+
+	[CommandLineArgument(IsPositional = true)]
+	[Description("The path of the folder containing the game's executable.")]
+	public required string SourceDir { get; set; }
+
+	[CommandLineArgument(IsPositional = true)]
+	[Description("The path to extract to. It may be an empty folder, or it may point to a nonexistent folder.")]
+	public required string OutputDir { get; set; }
+
+	[CommandLineArgument(DefaultValue = false)]
+	[Description("If true, the application will log to a file.")]
+	public bool Log { get; set; }
+
+	[CommandLineArgument(DefaultValue = null)]
+	[Description("The file location at which to save the log, or a sensible default if not provided.")]
+	public string? LogPath { get; set; }
+}
+
+internal enum ExtractMode
+{
+	UnityProject = 0,
+	PrimaryContent = 1,
+}

--- a/Source/AssetRipper.GUI.Web/WebApplicationLauncher.cs
+++ b/Source/AssetRipper.GUI.Web/WebApplicationLauncher.cs
@@ -367,7 +367,7 @@ public static class WebApplicationLauncher
 		}
 	}
 
-	private static void RotateLogs(string path)
+	public static void RotateLogs(string path)
 	{
 		const int MaxLogFiles = 5;
 		string? directory = Path.GetDirectoryName(path);

--- a/Source/AssetRipper.GUI.Web/WelcomeMessage.cs
+++ b/Source/AssetRipper.GUI.Web/WelcomeMessage.cs
@@ -2,7 +2,7 @@
 
 public static class WelcomeMessage
 {
-	private const string AsciiArt = """
+	public const string AsciiArt = """
 		                       _   _____  _                       
 		    /\                | | |  __ \(_)                      
 		   /  \   ___ ___  ___| |_| |__) |_ _ __  _ __   ___ _ __ 


### PR DESCRIPTION
<!--TODO set up CI
[![dev build for branch | YoshiRulz:cli-rebased](https://img.shields.io/badge/dev_build_for_branch-YoshiRulz:cli--rebased-8250DF?logo=github&logoColor=333333&style=popout)](https://nightly.link/YoshiRulz/AssetRipper/workflows/TODO/cli-rebased?preview)
-->

Simply exposes the "Export Unity Project" and "Export Primary Content" functions of the web interface via a new command-line interface:
```
$> AssetRipper.CLI unityproject "/path/to/game" "/target/output/path"
$> # and
$> AssetRipper.CLI primarycontent "/path/to/game" "/target/output/path"
```
You should also be able to compile it for macOS or Windows, though I don't use those OSes.
edit: Also available [in Nixpkgs](https://github.com/YoshiRulz/nixpkgs/tree/assetripper-cli), sadly as a fork and not an overlay.

<!--
The upstream maintainer has shot down requests for a CLI, see my earlier PR below for details.
Personally, their attitude is pushing me to consider alternative tools, but for now I'm stuck with it.
-->